### PR TITLE
Use super kawaii regex for splitting to fix #35

### DIFF
--- a/uwuify/core.py
+++ b/uwuify/core.py
@@ -97,14 +97,14 @@ def _do_stutter(entry: str, stutter_every_nth_word: int = 4) -> str:
             f"stutter_every_nth_word must be above 0; passed {stutter_every_nth_word}"
         )
 
-    listofstr = entry.split(" ")
+    listofstr = re.split(r"(\s+)", entry)
     result = []
     for index, word in enumerate(listofstr):
-        if index % stutter_every_nth_word == 0:
+        if index % stutter_every_nth_word == 0 and not word.isspace() and word != "":
             result.append("{}-{}{}".format(word[0], word[0], word[1:]))
         else:
             result.append(word)
-    return " ".join(result)
+    return "".join(result)
 
 
 def uwu(entry: Union[list, str], *, flags: UwuifyFlag = UwuifyFlag.NONE) -> str:

--- a/uwuify/core.py
+++ b/uwuify/core.py
@@ -99,11 +99,13 @@ def _do_stutter(entry: str, stutter_every_nth_word: int = 4) -> str:
 
     listofstr = re.split(r"(\s+)", entry)
     result = []
-    for index, word in enumerate(listofstr):
-        if index % stutter_every_nth_word == 0 and not word.isspace() and word != "":
-            result.append("{}-{}{}".format(word[0], word[0], word[1:]))
-        else:
-            result.append(word)
+    words_since_last_stutter = 0
+    for word in listofstr:
+        if word != "" and not word.isspace():
+            if words_since_last_stutter % stutter_every_nth_word == 0:
+                word = "{}-{}".format(word[0], word)
+            words_since_last_stutter += 1
+        result.append(word)
     return "".join(result)
 
 


### PR DESCRIPTION
T-The way the stwing was owiginally split wesults in an empty stwing as the fiwst element, so indexing it with `word[0]` fails, oopsie woopsie! O.O

I've weplaced `.split(" ")` with a kawaii regex that should also pwesewve the whitespaces in the owiginal stwing! UwU

I also intwoduced a cuuute running vawiable `words_since_last_stutter` that keeps twack of actual words in the stwing and ignowes whitespaces so `stutter_every_nth_word` wowks as expected XD *still twerking rapidly*